### PR TITLE
Fixed some markdown files that were not displaying correctly

### DIFF
--- a/Hands-on lab/Before the HOL - Containers and DevOps.md
+++ b/Hands-on lab/Before the HOL - Containers and DevOps.md
@@ -319,43 +319,43 @@ In this section, you will validate that you can connect to the new build agent V
 
 In this task, you will update the packages and install Docker engine.
 
-1.  Go to the WSL window that has the SSH connection open to the build agent VM
+1. Go to the WSL window that has the SSH connection open to the build agent VM
 
-2.  Update the Ubuntu packages and install curl and support for repositories over HTTPS in a single step by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
+2. Update the Ubuntu packages and install curl and support for repositories over HTTPS in a single step by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
 
     ``` bash
     sudo apt-get update && sudo apt install apt-transport-https ca-certificates curl software-properties-common
     ```
 
-3.  Add Docker's official GPG key by typing the following in a single line command
+3. Add Docker's official GPG key by typing the following in a single line command
 
     ``` bash
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     ```
-4.  Add Docker's stable repository to Ubuntu packages list by typing the following in a single line command
+4. Add Docker's stable repository to Ubuntu packages list by typing the following in a single line command
 
     ``` bash
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     ```
-5.  Update the Ubuntu packages and install Docker engine, node.js and the node package manager in a single step by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
+5. Update the Ubuntu packages and install Docker engine, node.js and the node package manager in a single step by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
 
     ``` bash
     sudo apt-get update && sudo apt install docker-ce nodejs npm mongodb-clients
     ```
-6.  Now, upgrade the Ubuntu packages to the latest version by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
+6. Now, upgrade the Ubuntu packages to the latest version by typing the following in a single line command. When asked if you would like to proceed, respond by typing "y" and pressing enter.
 
     ``` bash
     sudo apt-get upgrade
     ```
 
-7.  Install `docker-compose`
+7. Install `docker-compose`
 
     ```bash
     sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-8.  When the command has completed, check the Docker version installed by executing this command. The output may look something like that shown in the following screen shot. Note that the server version is not shown yet, because you didn't run the command with elevated privileges (to be addressed shortly).
+8. When the command has completed, check the Docker version installed by executing this command. The output may look something like that shown in the following screen shot. Note that the server version is not shown yet, because you didn't run the command with elevated privileges (to be addressed shortly).
 
     ``` bash
     docker version
@@ -363,7 +363,7 @@ In this task, you will update the packages and install Docker engine.
 
     ![In this screenshot of a Command Prompt window, docker version has been typed and run at the command prompt. Docker version information appears in the window.](images/Setup/image28.png)
 
-9.  You may check the versions of node.js and npm as well, just for information purposes, using these commands
+9. You may check the versions of node.js and npm as well, just for information purposes, using these commands
 
     ``` bash
     nodejs --version
@@ -371,14 +371,14 @@ In this task, you will update the packages and install Docker engine.
     npm -version
     ```
 
-10.  Install `bower`
+10. Install `bower`
 
     ```bash
     sudo npm install -g bower
     sudo ln -s /usr/bin/nodejs /usr/bin/node
     ```
 
-11.  Add your user to the Docker group so that you do not have to elevate privileges with sudo for every command. You can ignore any errors you see in the output.
+11. Add your user to the Docker group so that you do not have to elevate privileges with sudo for every command. You can ignore any errors you see in the output.
     ``` bash
     sudo usermod -aG docker $USER
     ```
@@ -614,7 +614,7 @@ FabMedical has provided starter files for you. They have taken a copy of one of 
     content-web/
     ```
 
-6. Next log into your VisualStudio.com account
+6.  Next log into your VisualStudio.com account
 
     If this is your first time logging into this account you will be taken through a first-run experience
 
@@ -622,7 +622,7 @@ FabMedical has provided starter files for you. They have taken a copy of one of 
     * Select "Create new account"
     * Enter a fabmedical-SUFFIX for your account name and select Continue
 
-7. Create repositories to host the code
+7.  Create repositories to host the code
 
     * Select the icon in the top left corner to return to the account home page
 
@@ -632,17 +632,17 @@ FabMedical has provided starter files for you. They have taken a copy of one of 
         * Enter fabmedical as the project name
         * Select "Create"
         
-    c. Once the project creation has completed, select "Code"
+    * Once the project creation has completed, select "Code"
     
-    d. Use the repository dropdown to create a new repository by selecting "+ New repository"
+    * Use the repository dropdown to create a new repository by selecting "+ New repository"
     
-           ![Repository dropdown](images/Setup/image48.png)
+        ![Repository dropdown](images/Setup/image48.png)
            
     * Enter "content-web" as the repository name
     
     * Once the project is created click "Generate Git credentials"
     
-          ![Generate Git Credentials](images/Setup/image50.png)
+        ![Generate Git Credentials](images/Setup/image50.png)
           
         * Enter a password
         * Confirm the password
@@ -690,7 +690,7 @@ FabMedical has provided starter files for you. They have taken a copy of one of 
         
         * When prompted, enter your VisualStudio.com username and the git credentials password you created earlier in this task
 
-8. Clone your repositories to the build agent
+8.  Clone your repositories to the build agent
 
     * From WSL, connect to the build agent VM as you did previously in Before the hands-on lab - Task 6: Connect securely to the build agent using the SSH command.
 

--- a/Hands-on lab/HOL step-by-step - Containers and DevOps.md
+++ b/Hands-on lab/HOL step-by-step - Containers and DevOps.md
@@ -99,7 +99,7 @@ Each tenant will have the following containers:
 
 ## Requirements
 
-1.  Microsoft Azure subscription must be pay-as-you-go or MSDN
+1. Microsoft Azure subscription must be pay-as-you-go or MSDN
 
     -  Trial subscriptions will *not* work
 
@@ -107,7 +107,7 @@ Each tenant will have the following containers:
 
     -  You must have enough cores available in your subscription to create the build agent and Azure Kubernetes Service cluster in Task 5: Create a build agent VM and Task 10: Create an Azure Kubernetes Service cluster. You'll need eight cores if following the exact instructions in the lab, or more if you choose additional agents or larger VM sizes. If you execute the steps required before the lab, you will be able to see if you need to request more cores in your sub.
 
-2.  Local machine or a virtual machine configured with:
+2. Local machine or a virtual machine configured with:
 
     -   A browser, preferably Chrome for consistency with the lab implementation tests
 
@@ -117,7 +117,7 @@ Each tenant will have the following containers:
 
         -   On Mac, all instructions should be executed using bash in Terminal
 
-3.  You will be asked to install other tools throughout the exercises.
+3. You will be asked to install other tools throughout the exercises.
 
 **VERY IMPORTANT: You should be typing all of the commands as they appear in the guide, except where explicitly stated in this document. Do not try to copy and paste from Word to your command windows or other documents where you are instructed to enter information shown in this document. There can be issues with Copy and Paste from Word that result in errors, execution of instructions, or creation of file content.**
 
@@ -454,21 +454,21 @@ In this task, you will create a new Dockerfile that will be used to run the API 
 
     ![The node image (node) and your container image (content-api) are visible in this screenshot of the WSL window.](images/Hands-onlabstep-by-step-ContainersandDevOpsimages/media/image59.png)
 
-1. Commit and push the new Dockerfile before continuing.
+4. Commit and push the new Dockerfile before continuing.
 
     - `git add .`
     - `git commit -m "Added Dockerfile"`
     - `git push`
     - Enter credentials if prompted.
 
-4. Navigate to the content-web folder again and list the files. Note that this folder already has a Dockerfile.
+5. Navigate to the content-web folder again and list the files. Note that this folder already has a Dockerfile.
 
     ```bash
     cd ../content-web
     ll
     ```
 
-5. View the Dockerfile contents -- which are similar to the file you created previously in the API folder. Type the following command:
+6. View the Dockerfile contents -- which are similar to the file you created previously in the API folder. Type the following command:
 
     ```bash
     cat Dockerfile
@@ -476,13 +476,13 @@ In this task, you will create a new Dockerfile that will be used to run the API 
 
     Notice that the content-web Dockerfile build stage includes additional tools to install bower packages in addition to the npm packages.
 
-6. Type the following command to create a Docker image for the web application
+7. Type the following command to create a Docker image for the web application
 
     ```bash
     docker build -t content-web .
     ```
 
-7. When complete, you will see seven images now exist when you run the Docker images command
+8. When complete, you will see seven images now exist when you run the Docker images command
 
     ```bash
     docker images
@@ -551,13 +551,13 @@ The web application container will be calling endpoints exposed by the API appli
     curl http://localhost:3001/speakers
     ```
 
-5. Create and start the web application container with a similar Docker run command -- instruct the docker engine to use any port with the `-P` command.
+6. Create and start the web application container with a similar Docker run command -- instruct the docker engine to use any port with the `-P` command.
 
     ```bash
     docker run --name web --net fabmedical -P -d content-web
     ```
 
-6. Enter the command to show running containers again and you'll observe that both the API and web containers are in the list. The web container shows a dynamically assigned port mapping to its internal container port 3000.
+7. Enter the command to show running containers again and you'll observe that both the API and web containers are in the list. The web container shows a dynamically assigned port mapping to its internal container port 3000.
 
     ```bash
     docker container ls
@@ -565,7 +565,7 @@ The web application container will be calling endpoints exposed by the API appli
 
     ![In this screenshot of the WSL window, docker container ls has again been typed and run at the command prompt. 0.0.0.0:32768->3000/tcp is highlighted under Ports, and a red arrow is pointing at it.](images/Hands-onlabstep-by-step-ContainersandDevOpsimages/media/image62.png)
 
-7. Test the web application by curling the URL. For the port, use the dynamically assigned port, which you can find in the output from the previous command. You will see HTML output, as you did when testing previously.
+8. Test the web application by curling the URL. For the port, use the dynamically assigned port, which you can find in the output from the previous command. You will see HTML output, as you did when testing previously.
 
     ```bash
     curl http://localhost:[PORT]/speakers.html
@@ -1436,7 +1436,7 @@ In this task, you will increase the number of instances for the API deployment i
 
     ![In the Scale a Deployment dialog box, 2 is entered in the Desired number of pods box.](images/Hands-onlabstep-by-step-ContainersandDevOpsimages/media/image116.png)
 
-**NOTE: If the deployment completes quickly, you may not see the deployment Waiting states in the dashboard as described in the following steps**.
+    **NOTE: If the deployment completes quickly, you may not see the deployment Waiting states in the dashboard as described in the following steps**.
 
 4. From the Replica Set view for the API, you'll see it is now deploying and that there is one healthy instance and one pending instance
 
@@ -2080,13 +2080,13 @@ In this task you will setup a Kubernetes Ingress to take advantage of path based
 
 In this exercise, you will de-provision any Azure resources created in support of this lab.
 
-1.  Delete both of the Resource Groups in which you placed all of your Azure resources
+1. Delete both of the Resource Groups in which you placed all of your Azure resources
 
      -  From the Portal, navigate to the blade of your Resource Group and then select Delete in the command bar at the top
 
      -   Confirm the deletion by re-typing the resource group name and selecting Delete
 
-2.  Delete the Service Principal created on Task 9: Create a Service Principal before the hands-on lab
+2. Delete the Service Principal created on Task 9: Create a Service Principal before the hands-on lab
     ```
     az ad sp delete --id "Fabmedical-sp"
     ```


### PR DESCRIPTION
A few images and code blocks were not displaying correctly due to whitespace issues with the markdown. Non-consistent spacing seems to be the issues. I've tested these changes on GitHub's markdown viewer and VS Code markdown preview.

[Before the HOL - Containers and DevOps.md](https://github.com/Microsoft/MCW-Containers-and-DevOps/blob/master/Hands-on%20lab/Before%20the%20HOL%20-%20Containers%20and%20DevOps.md)
Task 7, sub-items 10 was displaying the code block incorrectly. and 11 was not showing the image. Task 13 goes between unnumbered (or unlettered) to lettered sub-tasks. Also under Task 13 the "Repository Dropdown" and "Generate Git Credentials" images are not showing.

[HOL step-by-step - Containers and DevOps.md](https://github.com/Microsoft/MCW-Containers-and-DevOps/blob/master/Hands-on%20lab/HOL%20step-by-step%20-%20Containers%20and%20DevOps.md)
Exercise 2, Task 1, sub-item a is not displaying the image. Same with the next task (2) sub-item a.