### PR TITLE
Update azuredeploy.parameters.json

### DIFF
--- a/Hands-on lab/arm/azuredeploy.parameters.json
+++ b/Hands-on lab/arm/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "Suffix": {
-            "value": "SUF"
+            "value": "suf"
         },
         "VirtualMachineAdminUsername": {
             "value": "adminfabmedical"


### PR DESCRIPTION
Line 6 = change SUF to suf as this is used as part of the Cosmos DB account name which only accepts lower case. 

https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-manage-database-account

When run with default suffix; an error is generated:

Deployment failed. Correlation ID: d54e0e2c-5103-4944-b817-92dd2688c43a. {
  "code": "BadRequest",
  "message": "The character 'S' at index 11 is not allowed in the DatabaseAccount name\r\nActivityId: b2074a0e-a937-4273-84b9-a888462a3c4c, Microsoft.Azure.Documents.Common/2.4.0.0"
}